### PR TITLE
Add support for branches with forward slash

### DIFF
--- a/_ruby_libs/vcs.rb
+++ b/_ruby_libs/vcs.rb
@@ -187,7 +187,11 @@ class GIT < VCS
       if branch.name == 'git-svn' then next end
 
       # get the branch shortname
-      branch_name = branch.name.split('/')[-1]
+      if explicit_version and explicit_version.split('/').size > 1
+        branch_name = branch.name.split('/').drop(1).join("/")
+      else
+        branch_name = branch.name.split('/')[-1]
+      end
 
       # detached branches are those checked out by the system but not given names
       if branch.name.include? 'detached' then next end


### PR DESCRIPTION
Currently, if a source or doc repo uses a version name with forward slashes, the name is shortened only to the last element.  We have a package where the documentation is pulled from the release github uri under the branch 'release/indigo/python_trep'.  To fix this, I've changed it so when the desired branch name contains forward slashes, only the first element of the branch is dropped (usually 'origin/').  I'm not sure if there's a situation when multiple elements would need to be dropped though for better generality.